### PR TITLE
Find and fix three bugs

### DIFF
--- a/src/pages/CollaborationDetailPage.tsx
+++ b/src/pages/CollaborationDetailPage.tsx
@@ -109,10 +109,10 @@ export const CollaborationDetailPage: React.FC = () => {
           setApplications(applicationsData);
           const userApplication = applicationsData.find(app => app.applicantId === currentUser?.uid);
           setHasApplied(!!userApplication);
-        } else {
-          // Handle case where collaborationData is null but no explicit error
-          setError('Collaboration not found');
         }
+      } else {
+        // Handle case where collaborationData is null but no explicit error
+        setError('Collaboration not found');
       }
 
       setIsLoading(false);
@@ -352,7 +352,7 @@ export const CollaborationDetailPage: React.FC = () => {
                 </button>
                 <button
                   onClick={() => setIsDeleting(true)}
-                  className="inline-flex items-center px-3 py-1.5 border border-transparent rounded-md shadow-sm text-sm font-medium text-destructive-foreground bg-destructive hover:bg-destructive/90 focus:outline-none focus:ring-2 focus_ring-offset-2 focus:ring-destructive"
+                  className="inline-flex items-center px-3 py-1.5 border border-transparent rounded-md shadow-sm text-sm font-medium text-destructive-foreground bg-destructive hover:bg-destructive/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-destructive"
                 >
                   <Trash2 className="-ml-0.5 mr-2 h-4 w-4" />
                   Delete

--- a/src/pages/UserDirectoryPage.tsx
+++ b/src/pages/UserDirectoryPage.tsx
@@ -109,7 +109,9 @@ export const UserDirectoryPage: React.FC = () => {
         setRelationFilter(null);
         setRelationUserId(null);
       }
-    } catch (e) {}
+    } catch (e) {
+      console.error('Error processing URL parameters:', e);
+    }
 
     const fetchUsers = async () => {
       setLoading(true);


### PR DESCRIPTION
# Bug Fixes and Improvements

## Changes Overview

This PR addresses three distinct bugs: a logic error in collaboration detail page rendering, a CSS typo affecting focus styles, and an empty catch block in the user directory page, improving error visibility.

## Key Changes

1.  **Collaboration Detail Page Logic Fix**: Corrected the conditional rendering logic to properly display "Collaboration not found" when data is missing.
2.  **CSS Focus Ring Typo Fix**: Corrected a Tailwind CSS class typo (`focus_ring-offset` to `focus:ring-offset`) to ensure proper focus styling on buttons.
3.  **User Directory Error Handling Improvement**: Replaced an empty catch block with `console.error` to log exceptions during URL parameter processing, aiding debugging.

## Recent TypeScript Fixes (Latest Update)

*   ✅ **Collaboration Detail Page Logic**: Fixed conditional rendering for missing collaboration data.
*   ✅ **CSS Styling**: Corrected Tailwind CSS focus ring typo.
*   ✅ **Error Logging**: Added `console.error` to previously empty catch block.

## Test Coverage

No new automated tests were added for these minor fixes.

## Manual Testing Checklist

-   [ ] Verify "Collaboration not found" message appears correctly when a collaboration ID is invalid.
-   [ ] Verify delete button on collaboration detail page shows correct focus ring on interaction.
-   [ ] Verify no silent errors occur on User Directory page when URL parameters are malformed (check console for logs if issues arise).

## Related Documentation

N/A

---
<a href="https://cursor.com/background-agent?bcId=bc-79baf950-2daa-4f46-b620-9249761ce2d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-79baf950-2daa-4f46-b620-9249761ce2d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

