### PR TITLE
Investigate trade creation error

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,6 +72,7 @@ import ComprehensiveThemeTest from './components/ComprehensiveThemeTest';
 import ProfilePage from './pages/ProfilePage';
 import { TradesPage } from './pages/TradesPage';
 import { TradeDetailPage } from './pages/TradeDetailPage';
+import CreateTradePage from './pages/CreateTradePage';
 import PortfolioPage from './pages/PortfolioPage';
 import LoginPage from './components/auth/LoginPage';
 import DashboardPage from './pages/DashboardPage';
@@ -151,7 +152,8 @@ function App() {
           <Routes>
             <Route path="/" element={<RouteErrorBoundary><HomePage /></RouteErrorBoundary>} />
             <Route path="/trades" element={<RouteErrorBoundary><TradesPage /></RouteErrorBoundary>} />
-        <Route path="/trades/:tradeId" element={<RouteErrorBoundary><TradeDetailPage /></RouteErrorBoundary>} />
+            <Route path="/trades/new" element={<RouteErrorBoundary><ProtectedRoute><CreateTradePage /></ProtectedRoute></RouteErrorBoundary>} />
+            <Route path="/trades/:tradeId" element={<RouteErrorBoundary><TradeDetailPage /></RouteErrorBoundary>} />
         <Route path="/projects" element={<RouteErrorBoundary><CollaborationsPage /></RouteErrorBoundary>} />
         <Route path="/collaborations" element={<RouteErrorBoundary><CollaborationsPage /></RouteErrorBoundary>} />
         <Route path="/collaborations/new" element={<RouteErrorBoundary><CreateCollaborationPage /></RouteErrorBoundary>} />

--- a/src/utils/autoCreateUserProfile.ts
+++ b/src/utils/autoCreateUserProfile.ts
@@ -16,7 +16,7 @@ export async function autoCreateUserProfile() {
   if (!userSnap.exists()) {
     await setDoc(userRef, {
       name: user.displayName || user.email || user.uid,
-      email: user.email,
+      email: user.email || '', // Ensure email is always a string, not null
       createdAt: serverTimestamp(),
       roles: ['user']
     });


### PR DESCRIPTION
# Fix: Cannot Create New Trade - Missing Route & User Profile Email

## Changes Overview

This PR resolves the "Trade not found" error encountered when attempting to create a new trade. The primary issue was a missing route definition for the trade creation page, which caused incorrect routing to a non-existent trade detail page. Additionally, a minor fix was applied to user profile creation to prevent potential Firestore permission issues related to null email values.

## Key Changes

1.  **Added `/trades/new` Route:**
    *   A new route `/trades/new` has been added to `src/App.tsx` to correctly render the `CreateTradePage`.
    *   This ensures that navigation to create a new trade now directs users to the intended form, rather than misinterpreting "new" as a `tradeId` for the `TradeDetailPage`.

2.  **User Profile Email Null Handling:**
    *   Modified `src/utils/autoCreateUserProfile.ts` to ensure the `email` field in a new user's profile is always a string (defaulting to an empty string if `user.email` is null).
    *   This prevents potential Firestore security rule violations during user profile creation, which could indirectly affect subsequent user-specific operations.

## Recent TypeScript Fixes (Latest Update)

N/A (The primary fixes address routing and data handling logic, not TypeScript compilation errors.)

## Test Coverage

N/A (No new tests were added in this specific fix, but existing integration tests for trade creation should now pass.)

## Manual Testing Checklist

-   [ ] Verify that a new trade can be successfully created by navigating to the "Create Trade" page and submitting the form.
-   [ ] Confirm that the `CreateTradePage` renders correctly when accessing `/trades/new`.
-   [ ] Ensure user profiles are created correctly upon new user sign-up/login, especially for users whose authentication provider might not supply an email address.

## Related Documentation

N/A

---
<a href="https://cursor.com/background-agent?bcId=bc-2ab326e1-9723-48e4-9d9d-ca57e9764575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2ab326e1-9723-48e4-9d9d-ca57e9764575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

