### PR TITLE
Find and fix three bugs

### DIFF
--- a/src/components/ChatContainer.tsx
+++ b/src/components/ChatContainer.tsx
@@ -6,6 +6,7 @@
 
 import React, { useState } from 'react';
 import { useToast } from '../contexts/ToastContext';
+import { useAuth } from '../AuthContext';
 import { ChatConversationList } from './ChatConversationList';
 import { ChatMessageList } from './ChatMessageList';
 import { ChatInput } from './ChatInput';
@@ -28,6 +29,7 @@ export const ChatContainer: React.FC = () => {
   const [selectedConversation, setSelectedConversation] = useState<ChatConversation | null>(null);
   const [showConversationList, setShowConversationList] = useState(true);
   const { addToast } = useToast();
+  const { currentUser } = useAuth();
   
   // Handle new conversation
   const handleNewConversation = () => {
@@ -43,7 +45,7 @@ export const ChatContainer: React.FC = () => {
     
     // For direct conversations, show the other participant's name
     const otherParticipant = conversation.participants.find(
-      participant => participant.id !== 'current-user-id' // Replace with actual current user ID
+      participant => participant.id !== currentUser?.uid
     );
     
     return otherParticipant?.name || 'Unknown';

--- a/src/components/ChatConversationList.tsx
+++ b/src/components/ChatConversationList.tsx
@@ -54,7 +54,7 @@ export const ChatConversationList: React.FC<ChatConversationListProps> = ({
     });
     
     return () => unsubscribe();
-  }, [currentUser, selectedConversationId, onSelectConversation]);
+  }, [currentUser, selectedConversationId]);
   
   // Filter conversations based on search term
   const filteredConversations = conversations.filter(conversation => {
@@ -116,7 +116,7 @@ export const ChatConversationList: React.FC<ChatConversationListProps> = ({
     // Fallback avatar
     return (
       <div className="flex items-center justify-center w-10 h-10 rounded-full bg-primary/10 text-primary font-semibold">
-        {otherParticipant?.name.charAt(0).toUpperCase() || '?'}
+        {otherParticipant?.name?.charAt(0).toUpperCase() || '?'}
       </div>
     );
   };


### PR DESCRIPTION
# Chat Module Bug Fixes

## Changes Overview

This PR addresses three critical bugs within the chat module, improving user identification, optimizing `useEffect` hook behavior, and enhancing null-safety for UI rendering.

## Key Changes

1.  **Hardcoded User ID in ChatContainer:** Replaced a static placeholder with the authenticated user's ID (`currentUser?.uid`) from `useAuth` for accurate participant identification in chat conversations.
2.  **`useEffect` Dependency Optimization in ChatConversationList:** Removed the `onSelectConversation` prop from the `useEffect` dependency array to prevent unnecessary re-renders and re-subscriptions to Firebase listeners, improving performance.
3.  **Null-Safe Avatar Initial Display:** Enhanced the logic for displaying avatar initials in `ChatConversationList` by adding robust optional chaining (`otherParticipant?.name?.charAt(0)`) to safely handle cases where a participant's name might be undefined, preventing runtime errors.

## Bugs Fixed in this PR

-   ✅ **Hardcoded User ID:** Replaced `'current-user-id'` with `currentUser?.uid` in `ChatContainer.tsx`.
-   ✅ **`useEffect` Dependencies:** Removed `onSelectConversation` from `useEffect` dependencies in `ChatConversationList.tsx`.
-   ✅ **Null-Safe Avatar Initials:** Added optional chaining for `otherParticipant?.name?.charAt(0)` in `ChatConversationList.tsx`.

## Test Coverage

No new dedicated tests were added in this PR. The fixes address runtime logic and type safety within existing components. Existing chat-related tests should still apply.

## Manual Testing Checklist

-   [ ] Verify that chat conversations load and display correctly.
-   [ ] Confirm that participant names and avatars (initials) are rendered properly in the conversation list, especially for users with and without names.
-   [ ] Ensure messages can be sent and received within conversations.
-   [ ] Validate that the current authenticated user is correctly identified in chat interactions.

## Related Documentation

N/A

---
<a href="https://cursor.com/background-agent?bcId=bc-02125e80-0846-4c55-b855-a6b200e4ae34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-02125e80-0846-4c55-b855-a6b200e4ae34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

